### PR TITLE
common: Add global types for game abstraction

### DIFF
--- a/client/Client/Draw.hs
+++ b/client/Client/Draw.hs
@@ -5,6 +5,8 @@ import Control.Monad
 import qualified Data.Map as Map
 import Data.IORef
 
+import Common.Types
+
 import Client.Paths
 import Client.Settings
 
@@ -13,12 +15,6 @@ import Graphics.UI.Threepenny.Core
 
 
 type Position = (Int, Int)
-
-data Color = White | Black
-    deriving (Eq, Ord)
-
-data Piece = Rook | Knight | Bishop | Queen | King | Pawn
-    deriving (Eq, Ord)
 
 type MapRefs = (IORef (Map.Map Position (Color, Piece, Int)), IORef (Map.Map (Color, Piece) [Maybe Position]))
 

--- a/client/Client/Main.hs
+++ b/client/Client/Main.hs
@@ -4,6 +4,8 @@ import Data.Tuple.Select
 import Data.IORef
 import Data.Bifunctor
 
+import Common.Types
+
 import Client.Paths
 import Client.Draw
 import Client.Settings

--- a/client/client.cabal
+++ b/client/client.cabal
@@ -19,6 +19,7 @@ executable rookie-client
   build-depends:
       base >= 4.7 && < 5
     , threepenny-gui
+    , common
     , filepath
     , containers
     , tuple

--- a/common/Common/Types.hs
+++ b/common/Common/Types.hs
@@ -1,0 +1,23 @@
+module Common.Types where
+
+import Data.Array
+
+data Square = A1 | B1 | C1 | D1 | E1 | F1 | G1 | H1
+            | A2 | B2 | C2 | D2 | E2 | F2 | G2 | H2
+            | A3 | B3 | C3 | D3 | E3 | F3 | G3 | H3
+            | A4 | B4 | C4 | D4 | E4 | F4 | G4 | H4
+            | A5 | B5 | C5 | D5 | E5 | F5 | G5 | H5
+            | A6 | B6 | C6 | D6 | E6 | F6 | G6 | H6
+            | A7 | B7 | C7 | D7 | E7 | F7 | G7 | H7
+            | A8 | B8 | C8 | D8 | E8 | F8 | G8 | H8
+    deriving (Eq, Ord, Enum, Ix, Show)
+
+data Piece = Pawn | Knight | Bishop | Rook | Queen | King
+    deriving (Eq, Ord, Enum, Ix, Show)
+
+data Color = White | Black
+    deriving (Eq, Ord, Ix, Show)
+
+opposite :: Color -> Color
+opposite White = Black
+opposite Black = White

--- a/common/Setup.hs
+++ b/common/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/common/common.cabal
+++ b/common/common.cabal
@@ -1,0 +1,16 @@
+name:                common
+version:             0.1.0.0
+license:             BSD3
+author:              Piotr Wojtczak
+maintainer:          piotr.m.wojtczak@gmail.com
+build-type:          Simple
+cabal-version:       >=1.10
+
+library
+  exposed-modules:
+      Common.Types
+  default-language:
+      Haskell2010
+  build-depends:
+      base >= 4.7 && < 5
+    , array

--- a/common/stack.yaml
+++ b/common/stack.yaml
@@ -30,11 +30,7 @@ resolver:
 #   - auto-update
 #   - wai
 packages:
-- engine
-- client
-- Server
-- interfaces
-- common
+- .
 # Dependency packages to be pulled from upstream that are not in the resolver.
 # These entries can reference officially published versions as well as
 # forks / in-progress versions pinned to a git hash. For example:

--- a/engine/Engine/BoardState.hs
+++ b/engine/Engine/BoardState.hs
@@ -3,27 +3,8 @@ module Engine.BoardState where
 import Data.Word
 import Data.Array
 import Data.Bits
+import Common.Types
 import Engine.BitBoard
-
-data Square = A1 | B1 | C1 | D1 | E1 | F1 | G1 | H1
-            | A2 | B2 | C2 | D2 | E2 | F2 | G2 | H2
-            | A3 | B3 | C3 | D3 | E3 | F3 | G3 | H3
-            | A4 | B4 | C4 | D4 | E4 | F4 | G4 | H4
-            | A5 | B5 | C5 | D5 | E5 | F5 | G5 | H5
-            | A6 | B6 | C6 | D6 | E6 | F6 | G6 | H6
-            | A7 | B7 | C7 | D7 | E7 | F7 | G7 | H7
-            | A8 | B8 | C8 | D8 | E8 | F8 | G8 | H8
-    deriving (Eq, Ord, Enum, Ix, Show)
-
-data Piece = Pawn | Knight | Bishop | Rook | Queen | King
-    deriving (Eq, Ord, Enum, Ix, Show)
-
-data Color = White | Black
-    deriving (Eq, Ord, Ix, Show)
-
-opposite :: Color -> Color
-opposite White = Black
-opposite Black = White
 
 -- Castling rights
 

--- a/engine/Engine/Moves.hs
+++ b/engine/Engine/Moves.hs
@@ -5,6 +5,7 @@ module Engine.Moves (
 import Data.Array
 import Data.Bits
 import Data.Word
+import Common.Types
 import Engine.BitBoard
 import Engine.BoardState
 

--- a/engine/engine.cabal
+++ b/engine/engine.cabal
@@ -20,4 +20,5 @@ library
       Haskell2010
   build-depends:       
       base >= 4.7 && < 5
+    , common
     , array

--- a/interfaces/Interfaces/Notation.hs
+++ b/interfaces/Interfaces/Notation.hs
@@ -9,6 +9,7 @@ import Data.List.Split
 import Data.Bits
 import Control.Monad.State
 import qualified Data.Map as Map
+import Common.Types
 import Engine.BitBoard
 import Engine.BoardState
 

--- a/interfaces/interfaces.cabal
+++ b/interfaces/interfaces.cabal
@@ -13,6 +13,7 @@ library
       Haskell2010
   build-depends:
       base >= 4.7 && < 5
+    , common
     , engine
     , split
     , array


### PR DESCRIPTION
Types representing parts of the game like the pieces or the colors were defined locally in both the `engine` and the `client` package. Since their definitions and purpose are almost identical, let's unify them and share that code across the packages so the whole project is more cohesive.

For this purpose, a new package is created called `common`. This had to be done to avoid cyclic package dependencies resulting from putting the common types in the `interfaces` package.