### PR TITLE
interfaces: Add legal moves interface

### DIFF
--- a/engine/Engine/BitBoard.hs
+++ b/engine/Engine/BitBoard.hs
@@ -2,6 +2,7 @@ module Engine.BitBoard where
 
 import Data.Word
 import Data.Bits
+import Common.Types
 
 type BitBoard = Word64
 
@@ -49,6 +50,20 @@ full = complement empty
 
 isEmpty :: BitBoard -> Bool 
 isEmpty = (==) 0
+
+toSquares :: BitBoard -> [Square]
+toSquares bb =
+    if isEmpty bb then
+        []
+    else
+        let sq = countTrailingZeros bb in
+            toEnum sq : toSquares (bb `xor` square sq)
+
+fromSquares :: [Square] -> BitBoard
+fromSquares squares = foldl xor 0 $ map (square . fromEnum) squares
+
+fromSquare :: Square -> BitBoard
+fromSquare sq = fromSquares [sq]
 
 -- Pretty Printing
 pprint :: BitBoard -> String

--- a/engine/Engine/BoardState.hs
+++ b/engine/Engine/BoardState.hs
@@ -59,7 +59,7 @@ setPieces ps board = board {
     }
 
 startingPositions :: Color -> Piece -> BitBoard
-startingPositions color piece = sum $ map squareToBB $ getStartingSquares color piece
+startingPositions color piece = sum $ map fromSquare $ getStartingSquares color piece
 
 getStartingSquares :: Color -> Piece -> [Square]
 getStartingSquares color piece = case color of
@@ -82,12 +82,6 @@ getStartingSquares color piece = case color of
 
 squareToFileRank :: Square -> (Int, Int)
 squareToFileRank sq = (fileOf $ fromEnum sq, rankOf $ fromEnum sq)
-
-squareToBB :: Square -> BitBoard
-squareToBB sq = square $ fromEnum sq
-
-genBitBoardFromSquares :: [Square] -> BitBoard
-genBitBoardFromSquares squares = foldl xor 0 $ map (square . fromEnum) squares
 
 -- Piece helper functions
 

--- a/interfaces/Interfaces/LegalMoves.hs
+++ b/interfaces/Interfaces/LegalMoves.hs
@@ -1,0 +1,13 @@
+module Interfaces.LegalMoves (
+    getLegalMoves
+) where
+
+import Common.Types
+import Engine.BoardState
+import qualified Engine.BitBoard as BitBoard
+import qualified Engine.Moves (getValidMoves)
+
+getLegalMoves :: BoardState -> Square -> [Square]
+getLegalMoves board sq = case getPieceAt board sq of
+    Nothing         -> []
+    Just (color, p) -> BitBoard.toSquares $ Engine.Moves.getValidMoves board color p (BitBoard.square $ fromEnum sq)


### PR DESCRIPTION
Let's add a friendly API for querying legal moves to use outside of the `engine` package.