### PR TITLE
engine: Add Move data and basic makeMove function

### DIFF
--- a/engine/Engine/BoardState.hs
+++ b/engine/Engine/BoardState.hs
@@ -22,6 +22,7 @@ data BoardState = BoardState {
     allPieces :: Array Color BitBoard,
     enPassant :: BitBoard,
     castling :: Int, -- k q K Q
+    sideToMove :: Color,
     ply :: Int,
     eval :: Int
 }
@@ -38,6 +39,7 @@ initBoard =
             allPieces = listArray (White, Black) $ map sum pieceList,
             enPassant = 0,
             castling = castlingRight White King .|. castlingRight White Queen .|. castlingRight Black King .|. castlingRight Black Queen,
+            sideToMove = White,
             ply = 0,
             eval = 0
         }
@@ -48,6 +50,7 @@ emptyBoard = BoardState {
         allPieces = listArray (White, Black) $ replicate 2 0,
         enPassant = 0,
         castling = 0,
+        sideToMove = White,
         ply = 0,
         eval = 0
     }
@@ -86,12 +89,15 @@ squareToFileRank sq = (fileOf $ fromEnum sq, rankOf $ fromEnum sq)
 -- Piece helper functions
 
 containsPiece :: BoardState -> Square -> Color -> Piece -> Bool
-containsPiece state square color piece = testBit (pieces state ! color ! piece) $ fromEnum square
+containsPiece board square color piece = testBit (pieces board ! color ! piece) $ fromEnum square
+
+containsAnyPiece :: BoardState -> Square -> Bool
+containsAnyPiece board square = testBit (allPieces board ! White `xor` allPieces board ! Black) $ fromEnum square
 
 getPieceAt :: BoardState -> Square -> Maybe (Color, Piece)
-getPieceAt state square =
-    let white = map (\ p -> if containsPiece state square White p then Just (White, p) else Nothing) $ range (Pawn, King)
-        black = map (\ p -> if containsPiece state square Black p then Just (Black, p) else Nothing) $ range (Pawn, King)
+getPieceAt board square =
+    let white = map (\ p -> if containsPiece board square White p then Just (White, p) else Nothing) $ range (Pawn, King)
+        black = map (\ p -> if containsPiece board square Black p then Just (Black, p) else Nothing) $ range (Pawn, King)
         filtered = filter (/= Nothing) $ white ++ black
     in
         case filtered of

--- a/engine/engine.cabal
+++ b/engine/engine.cabal
@@ -22,3 +22,4 @@ library
       base >= 4.7 && < 5
     , common
     , array
+    , mtl

--- a/interfaces/Interfaces/Notation.hs
+++ b/interfaces/Interfaces/Notation.hs
@@ -25,6 +25,7 @@ parseFEN fen =
             modify (\ board -> board { castling = parseCastling castling })
             modify (\ board -> board { enPassant = if ep == "-" then 0 
                                                    else square $ (ord (head ep) - ord 'a') + 8 * (ord (ep !! 1) - ord '1') })
+            modify (\ board -> board { sideToMove = if side == "w" then White else Black })
     in
         execState (parse fen) emptyBoard
 


### PR DESCRIPTION
This change introduces the abstraction of a move as a differential
change from some state of the board. The Move object keeps track
of the information needed to apply the move, as well as some data
usefull for further move evaluation.

A makeMove function is also implemented, allowing to change any
board state by the application of the given move. This function produces
a valid board state - the result of playing the supplied move.

Currently there's no method for undoing moves.