### PR TITLE
interfaces: Add playMove API

### DIFF
--- a/interfaces/Interfaces/Play.hs
+++ b/interfaces/Interfaces/Play.hs
@@ -1,0 +1,19 @@
+module Interfaces.Play (
+    playMove
+) where
+
+import Engine.Search
+import Engine.Moves
+import Interfaces.Notation
+
+playMove :: FEN -> FEN
+playMove fen =
+    let game = parseFEN fen
+        best = search game
+    in
+        case best of
+            Nothing     -> startingPosition
+            Just move   -> encodeBoardState response where response = makeMove move game
+
+startingPosition :: FEN 
+startingPosition = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"

--- a/interfaces/interfaces.cabal
+++ b/interfaces/interfaces.cabal
@@ -10,6 +10,7 @@ library
   exposed-modules:
       Interfaces.Notation
     , Interfaces.LegalMoves
+    , Interfaces.Play
   default-language:
       Haskell2010
   build-depends:


### PR DESCRIPTION
This commit adds a playMove wrapper function into the interfaces package
to hide the inner working of the engine and only respond with FENs
containing played best moves.