### PR TITLE
interfaces: Don't send moves exposing the king to the client

### DIFF
--- a/engine/Engine/Moves.hs
+++ b/engine/Engine/Moves.hs
@@ -1,6 +1,6 @@
 module Engine.Moves (
     getValidMoves, getValidMovesForAll,
-    Move (..), genMoves, makeMove,
+    Move (..), genMoves, makeMove, isLegal,
     toAlgebraicNotation
 ) where
 
@@ -26,6 +26,7 @@ data Move = Move {
     isCheck :: Bool
 } deriving (Eq, Ord, Show)
 
+-- genMoves generates pseudoLegal moves, as the search will never allow for loosing the king anyway
 genMoves :: BoardState -> [Move]
 genMoves board =
     let side = sideToMove board
@@ -69,6 +70,15 @@ makeMove move board = flip execState board $ do
         modify (\ board -> board { enPassant = square $ fromEnum (from move) + 8 * dir })
     else
         modify (\ board -> board { enPassant = 0 })
+
+isLegal :: Move -> BoardState -> Bool
+isLegal move board =
+    let player = sideToMove board
+        newBoard = makeMove move board
+        attackedSquares = foldl (.|.) 0 $ map (getValidMovesForAll newBoard (opposite player)) $ range (Pawn, King)
+        king = pieces newBoard ! player ! King
+    in
+        isEmpty $ king .&. attackedSquares
 
 toAlgebraicNotation :: Move -> String
 toAlgebraicNotation move =

--- a/interfaces/Interfaces/LegalMoves.hs
+++ b/interfaces/Interfaces/LegalMoves.hs
@@ -5,9 +5,9 @@ module Interfaces.LegalMoves (
 import Common.Types
 import Engine.BoardState
 import qualified Engine.BitBoard as BitBoard
-import qualified Engine.Moves (getValidMoves)
+import qualified Engine.Moves (genMoves, isLegal, Move (..))
 
 getLegalMoves :: BoardState -> Square -> [Square]
 getLegalMoves board sq = case getPieceAt board sq of
     Nothing         -> []
-    Just (color, p) -> BitBoard.toSquares $ Engine.Moves.getValidMoves board color p (BitBoard.square $ fromEnum sq)
+    Just (color, p) -> map Engine.Moves.to $ filter ((== sq) . Engine.Moves.from) $ filter (`Engine.Moves.isLegal` board) $ Engine.Moves.genMoves board


### PR DESCRIPTION
For the purposes of the engine we only generate pseudo legal
moves as there is no need for the explicit check - the engine
will never want to lose the king.
However, in the exposed interface for the legal moves we should
filter out the moves that leave the king in check.