### PR TITLE
engine: Recognize states with checked kings and moves that lead to them

### DIFF
--- a/engine/Engine/BoardState.hs
+++ b/engine/Engine/BoardState.hs
@@ -23,6 +23,7 @@ data BoardState = BoardState {
     enPassant :: BitBoard,
     castling :: Int, -- k q K Q
     sideToMove :: Color,
+    kingInCheck :: Bool,
     ply :: Int,
     eval :: Float
 }
@@ -40,6 +41,7 @@ initBoard =
             enPassant = 0,
             castling = castlingRight White King .|. castlingRight White Queen .|. castlingRight Black King .|. castlingRight Black Queen,
             sideToMove = White,
+            kingInCheck = False,
             ply = 0,
             eval = 0
         }
@@ -51,6 +53,7 @@ emptyBoard = BoardState {
         enPassant = 0,
         castling = 0,
         sideToMove = White,
+        kingInCheck = False,
         ply = 0,
         eval = 0
     }


### PR DESCRIPTION
It will further help the evaluation to know whether the king
in the current position is in check and whether a generated move
is actually a checking one.
Moreover, having the BoardState be aware of this gives the client
more info on the current position.