### PR TITLE
ci: GitHub action building project on each PR and push to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+    pull_request:
+    push:
+        branches: [master]
+
+jobs:
+    stack:
+        name: stack / ghc ${{ matrix.ghc }}
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                ghc: ["8.10.4"]
+
+        steps:
+            - uses: actions/checkout@v2
+            - uses: haskell/actions/setup@v1
+              with:
+                  ghc-version: ${{ matrix.ghc }}
+                  enable-stack: true
+                  stack-version: 'latest'
+            - uses: actions/cache@v2.1.6
+              name: Cache ~/.stack
+              with:
+                  path: ~/.stack
+                  key: ${{ runner.os }}-${{ matrix.ghc }}-stack
+
+            - name: Install dependencies
+              run: stack build --system-ghc --test --bench --no-run-tests --no-run-benchmarks --only-dependencies
+
+            - name: Build
+              run: stack build --system-ghc --test --no-run-tests --no-run-benchmarks
+
+            - name: Test
+              run: stack test --system-ghc
+          

--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 # Rookie
+[![GitHub CI](https://github.com/StarostaGit/Rookie/workflows/CI/badge.svg)](https://github.com/StarostaGit/Rookie/actions)


### PR DESCRIPTION
This PR introduces GitHub Actions to our project. 
Now after each pull request and push to master the project will be built.
It is also configured to run tests, if there are any.
Later we can configure it to allow merging to master only after action's success
and optionally require PR approval. We could also disable direct pushing to master.

Building dependencies is cached as this process can take several
minutes, but on each dependencies change the project has to be
built from scratch.

Added a build badge to `README.md`.